### PR TITLE
Fixing array memory access issue

### DIFF
--- a/RRTStar/rrt_star.py
+++ b/RRTStar/rrt_star.py
@@ -13,35 +13,35 @@ def main():
     path is not found.
     """
     print(__file__ + " start!!")
-    sim_loop = 50
+    sim_loop = 100
     area = 20.0  # animation area length [m]
     show_animation = True
 
-    conds = {'wx': [150.0],
-             'wy': [195.0],
-             'obstacle_list': [10 * [134., 194., 136., 196.]],
-             'x': 120.0,
-             'y': 195.0,
-             }  # paste output from debug log
+    conds = {
+        'start': [150, 60],
+         'end': [170, 60],
+        'obstacles': [
+            [158, 57,
+             162, 63]
+        ],
+        'step_size': 0.5,
+        'max_iterations': 2000
+    }  # paste output from debug log
 
-    # way points
-    wx = np.array(conds['wx'])
-    wy = np.array(conds['wy'])
-    wp = np.array([wx, wy]).T
+    start = conds['start']
+    end = conds['end']
+    max_iterations = conds['max_iterations']
+    step_size = conds['step_size']
+    obs = np.array(conds['obstacles'])
 
-    # initial conditions
-    x = conds['x']
-    y = conds['y']
-
-    # obstacle lists
-    obs = np.array(conds['obstacle_list'])
     total_time_taken = 0
+    x, y = start
     for i in range(sim_loop):
         print("Iteration: {}".format(i))
         start_time = time.time()
         success, (result_x, result_y) = \
-            rrt_star_wrapper.apply_rrt_star([x, y], wp[-1], 1,
-                                           2000, obs)
+            rrt_star_wrapper.apply_rrt_star([x, y], end, step_size,
+                                            max_iterations, obs)
         if success == 1:
             x = result_x[1]
             y = result_y[1]
@@ -51,7 +51,7 @@ def main():
         total_time_taken += end_time
         print("Time taken: {}".format(end_time))
 
-        if np.hypot(result_x[1] - wx[-1], result_y[1] - wy[-1]) <= 2.0:
+        if np.hypot(x - end[0], y - end[1]) <= 1.0:
             print("Goal")
             break
 
@@ -63,15 +63,18 @@ def main():
                 lambda event: [exit(0) if event.key == 'escape' else None]
             )
             ax = plt.gca()
-            rect = patch.Rectangle((obs[0, 0], obs[0, 1]),
-                                   obs[0, 2] - obs[0, 0], obs[0, 3] - obs[0, 1])
-            ax.add_patch(rect)
-            plt.plot(wp[:, 0], wp[:, 1])
-            plt.plot(result_x[1:], result_y[1:], ".r")
-            plt.plot(result_x[1], result_y[1], "vc")
-            plt.plot(wp[-1, 0], wp[-1, 1], "og")
-            plt.xlim(result_x[1] - area, result_x[1] + area)
-            plt.ylim(result_y[1] - area, result_y[1] + area)
+            for o in obs:
+                rect = patch.Rectangle((o[0], o[1]),
+                                       o[2] - o[0],
+                                       o[3] - o[1])
+                ax.add_patch(rect)
+            plt.plot(start[0], start[1], "og")
+            plt.plot(end[0], end[1], "or")
+            if success:
+                plt.plot(result_x[1:], result_y[1:], ".r")
+                plt.plot(result_x[1], result_y[1], "vc")
+                plt.xlim(result_x[1] - area, result_x[1] + area)
+                plt.ylim(result_y[1] - area, result_y[1] + area)
             plt.xlabel("X axis")
             plt.ylabel("Y axis")
             plt.grid(True)

--- a/RRTStar/rrt_star_wrapper.py
+++ b/RRTStar/rrt_star_wrapper.py
@@ -40,10 +40,10 @@ def apply_rrt_star(start, end, step_size, max_iterations, obs):
     result_x = np.zeros(100)
     result_y = np.zeros(100)
 
-    llx = np.copy(obs[:, 0])
-    lly = np.copy(obs[:, 1])
-    urx = np.copy(obs[:, 2])
-    ury = np.copy(obs[:, 3])
+    llx = np.copy(obs[:, 0]).astype(np.float64)
+    lly = np.copy(obs[:, 1]).astype(np.float64)
+    urx = np.copy(obs[:, 2]).astype(np.float64)
+    ury = np.copy(obs[:, 3]).astype(np.float64)
 
     success = _apply_rrt_star(
         c_double(start[0]), c_double(start[1]), c_double(end[0]),

--- a/RRTStar/rrt_star_wrapper.py
+++ b/RRTStar/rrt_star_wrapper.py
@@ -39,13 +39,19 @@ def apply_rrt_star(start, end, step_size, max_iterations, obs):
     """
     result_x = np.zeros(100)
     result_y = np.zeros(100)
+
+    llx = np.copy(obs[:, 0])
+    lly = np.copy(obs[:, 1])
+    urx = np.copy(obs[:, 2])
+    ury = np.copy(obs[:, 3])
+
     success = _apply_rrt_star(
         c_double(start[0]), c_double(start[1]), c_double(end[0]),
         c_double(end[1]), c_double(step_size), c_int(max_iterations),
-        obs[:, 0].ctypes.data_as(_c_double_p),
-        obs[:, 1].ctypes.data_as(_c_double_p),
-        obs[:, 2].ctypes.data_as(_c_double_p),
-        obs[:, 3].ctypes.data_as(_c_double_p),
+        llx.ctypes.data_as(_c_double_p),
+        lly.ctypes.data_as(_c_double_p),
+        urx.ctypes.data_as(_c_double_p),
+        ury.ctypes.data_as(_c_double_p),
         c_int(obs.shape[0]),
         result_x.ctypes.data_as(_c_double_p),
         result_y.ctypes.data_as(_c_double_p),
@@ -55,4 +61,4 @@ def apply_rrt_star(start, end, step_size, max_iterations, obs):
     if success and np.any(np.isnan(result_x)):
         ind = np.where(np.isnan(result_x))[0][0]
 
-    return (success, (result_x[:ind], result_y[:ind]))
+    return success, (result_x[:ind], result_y[:ind])

--- a/src/RRTStar/RRTStarWrapper.cpp
+++ b/src/RRTStar/RRTStarWrapper.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <eigen3/Eigen/Dense>
+#include <vector>
 #include <map>
 
 double SPACEDIM = 2.0;
@@ -99,10 +100,15 @@ extern "C" {
                 max_iterations);
 
         // Construct obstacles
+        vector<double> llx (obstacles_llx, obstacles_llx + numObstacles);
+        vector<double> lly (obstacles_llx, obstacles_llx + numObstacles);
+        vector<double> urx (obstacles_llx, obstacles_llx + numObstacles);
+        vector<double> ury (obstacles_llx, obstacles_llx + numObstacles);
+
         for (int i = 0; i < numObstacles; i++) {
             rrt->addObstacle(
-                    Vector2f(obstacles_llx[i], obstacles_lly[i]),
-                    Vector2f(obstacles_urx[i], obstacles_ury[i])
+                    Vector2f(llx[i], lly[i]),
+                    Vector2f(urx[i], ury[i])
             );
         }
 

--- a/src/RRTStar/RRTStarWrapper.cpp
+++ b/src/RRTStar/RRTStarWrapper.cpp
@@ -101,9 +101,9 @@ extern "C" {
 
         // Construct obstacles
         vector<double> llx (obstacles_llx, obstacles_llx + numObstacles);
-        vector<double> lly (obstacles_llx, obstacles_llx + numObstacles);
-        vector<double> urx (obstacles_llx, obstacles_llx + numObstacles);
-        vector<double> ury (obstacles_llx, obstacles_llx + numObstacles);
+        vector<double> lly (obstacles_lly, obstacles_lly + numObstacles);
+        vector<double> urx (obstacles_urx, obstacles_urx + numObstacles);
+        vector<double> ury (obstacles_ury, obstacles_ury + numObstacles);
 
         for (int i = 0; i < numObstacles; i++) {
             rrt->addObstacle(


### PR DESCRIPTION
This took a long time to find...

Basically `[i]` indexing into the obstacle pointer was incorrectly grabbing the elements. Numpy arrays are stored contiguously, which can cause problems when indexing naively. For example:
```
obstacles = np.array([[1, 2, 3, 4]])
obstacles[:, 0].ctypes.data_as(double_ptr)  # Address = x
obstacles[:, 1].ctypes.data_as(double_ptr)  # Address = x+8
...
```
Thus if we call a `cdll` function like this:
```
my_cdll_func(..., obstacles[:, 0].ctypes.data_as(double_ptr), obstacles[:, 1].ctypes.data_as(double_ptr), ...)
...
```
And we index it like this:
```
void my_cdll_func(double* ox, double* oy) {
    for (int i = 0; i < n; i++) {
        cout << ox[i] << " " << oy[i] << endl;
    }
}
```
The output will look like:
```
1 2
2 3
3 4
...
```
The results are staggered which was creating fake obstacles. My fix was to copy the columns of the obstacle array into new 1d arrays, which we can then access consecutively. 
